### PR TITLE
chore: professionalize makefile and update profile headline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,41 @@
-help: Show this help message
+.PHONY: help nix-% build clean format test cov cov-html
+
+GO ?= go
+BINARY_NAME = biohub
+
+help:
 	@echo "Available targets:"
+	@echo "  nix-%         Run a command within the nix-shell"
 	@echo "  build         Build the BioHub application"
 	@echo "  clean         Clean up build artifacts"
 	@echo "  format        Format the Go source code"
 	@echo "  test          Run unit tests"
-	@echo "  coverage      Generate test coverage report"
-	@echo "  coverage-html Generate HTML test coverage report"
+	@echo "  cov           Generate test coverage report"
+	@echo "  cov-html      Generate HTML test coverage report"
 	@echo "  help          Show this help message"
 
+nix-%:
+	@nix-shell --run "make $*"
 
 build:
-	go build -o biohub.exe cmd/build/main.go && ./biohub.exe && rm ./biohub.exe
+	@$(GO) build -o $(BINARY_NAME) cmd/build/main.go
+	@./$(BINARY_NAME)
+	@rm -f $(BINARY_NAME)
 
 clean:
-	rm -f biohub.exe 
-	rm -rf dist
+	@rm -f $(BINARY_NAME)
+	@rm -f coverage.out
+	@rm -rf dist
 
 format:
-	go fmt ./cmd/...
+	@$(GO) fmt ./cmd/...
 
 test:
-	go test ./cmd/... -v
+	@$(GO) test ./cmd/... -v
 
-coverage:
-	go test -cover ./cmd/...
+cov:
+	@$(GO) test -cover ./cmd/...
 
-coverage-html:
-	go test -coverprofile=coverage.out ./cmd/... && go tool cover -html=coverage.out
+cov-html:
+	@$(GO) test -coverprofile=coverage.out ./cmd/... && $(GO) tool cover -html=coverage.out
+	@rm -f coverage.out

--- a/config.yml
+++ b/config.yml
@@ -1,7 +1,7 @@
 Params:
   Avatar: "static/avatar.png"
   Name: "Victoria Cheng"
-  Headline: "Software Developer, SAIT ’26 | Go • TypeScript • Python | Building Observability Systems | prev Shopify Eng Intern"
+  Headline: "Software Developer (Systems) | Go, Python, Linux, TS | Grafana & Observability | Prev @ Shopify | SAIT ’26"
 
   Theme:
     Background: "#1f2937"


### PR DESCRIPTION
### Summary

Professionalized the `Makefile` to align with Senior+ engineering standards and updated the personal headline in `config.yml` to better reflect current technical focus and experience.

### List of Changes

- **Makefile:**
  - Added `nix-%` target to allow running any `make` target within a `nix-shell` seamlessly.
  - Implemented professional conventions: added `.PHONY`, used variables (`GO`, `BINARY_NAME`), and suppressed command echoing with `@`.
  - Shortened coverage targets to `cov` and `cov-html` for efficiency.
  - Enhanced `build` target to automatically remove the temporary binary after execution.
  - Improved `clean` and `cov-html` targets to ensure `coverage.out` is properly managed.
- **Config:**
  - Updated `Headline` in `config.yml` to emphasize Systems Development, Observability (Grafana), and professional experience.

### Verification

- Ran `make help` to verify the new target list.
- Ran `make nix-format` to verify Nix-shell integration.
- Verified `config.yml` content matches the intended professional profile.